### PR TITLE
External links open in new tab

### DIFF
--- a/__site/404.html
+++ b/__site/404.html
@@ -60,7 +60,7 @@
 </div>
 
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 </div><!-- CONTENT ENDS HERE -->
     

--- a/__site/code/index.html
+++ b/__site/code/index.html
@@ -37,7 +37,7 @@
 <div class="franklin-content"><h1 id="code"><a href="#code" class="header-anchor">Code</a></h1>
 <p>Here is where you&#39;ll find links to study group member&#39;s code&#33;</p>
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 </div><!-- CONTENT ENDS HERE -->
     

--- a/__site/index.html
+++ b/__site/index.html
@@ -35,12 +35,12 @@
 
 <!-- Content appended here -->
 <div class="franklin-content"><h1 id="julia_for_deep_learning"><a href="#julia_for_deep_learning" class="header-anchor">Julia for Deep Learning</a></h1>
-<p>A course repository to follow along fast.ai using <a href="https://julialang.org">Julia</a>&#33;</p>
-<p>Welcome&#33; Here’s where you can find all the information you’ll need on the course. The goal of these docs is to follow along with the course <a href="https://fast.ai">fast.ai</a>, a stellar deep learning course. fast.ai is implemented in Python, but I personally strongly prefer Julia, and have always wanted to learn more deep learning. </p>
+<p>A course repository to follow along fast.ai using <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia</a>&#33;</p>
+<p>Welcome&#33; Here’s where you can find all the information you’ll need on the course. The goal of these docs is to follow along with the course <a href="https://fast.ai" target="_blank" rel="nooopener noreferrer">fast.ai</a>, a stellar deep learning course. fast.ai is implemented in Python, but I personally strongly prefer Julia, and have always wanted to learn more deep learning.</p>
 <p>We’ll be implementing the fast.ai tutorials in Julia and going through them collaboratively. Every two weeks we’ll assign some reading and personal exercises, and then meet to discuss pain points/implementations/etc. </p>
-<p>Check out our <a href="https://github.com/cpfiffer/julia-deeplearning">GitHub</a> for more, and join our <a href="https://discord.gg/zr5RVdWxs2">Discord</a>&#33;</p>
+<p>Check out our <a href="https://github.com/cpfiffer/julia-deeplearning" target="_blank" rel="nooopener noreferrer">GitHub</a> for more, and join our <a href="https://discord.gg/zr5RVdWxs2" target="_blank" rel="nooopener noreferrer">Discord</a>&#33;</p>
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 </div><!-- CONTENT ENDS HERE -->
     

--- a/__site/resources/index.html
+++ b/__site/resources/index.html
@@ -38,11 +38,11 @@
 <p>Here&#39;s some handy links and references.</p>
 <h2 id="links"><a href="#links" class="header-anchor">Links</a></h2>
 <ul>
-<li><p><a href="https://fast.ai">fast.ai</a></p>
+<li><p><a href="https://fast.ai" target="_blank" rel="nooopener noreferrer">fast.ai</a></p>
 </li>
 </ul>
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 </div><!-- CONTENT ENDS HERE -->
     

--- a/__site/schedule/index.html
+++ b/__site/schedule/index.html
@@ -40,7 +40,7 @@
 </li>
 </ul>
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 </div><!-- CONTENT ENDS HERE -->
     

--- a/__site/sitemap.xml
+++ b/__site/sitemap.xml
@@ -2,26 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 <url>
-    <loc>https://tlienart.github.io/FranklinTemplates.jl/index.html</loc>
-    <lastmod>2023-07-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-</url>
-<url>
-    <loc>https://tlienart.github.io/FranklinTemplates.jl/resources/index.html</loc>
-    <lastmod>2023-07-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-</url>
-<url>
     <loc>https://tlienart.github.io/FranklinTemplates.jl/code/index.html</loc>
-    <lastmod>2023-07-22</lastmod>
+    <lastmod>2023-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
 </url>
 <url>
     <loc>https://tlienart.github.io/FranklinTemplates.jl/schedule/index.html</loc>
-    <lastmod>2023-07-22</lastmod>
+    <lastmod>2023-07-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+</url>
+<url>
+    <loc>https://tlienart.github.io/FranklinTemplates.jl/resources/index.html</loc>
+    <lastmod>2023-07-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+</url>
+<url>
+    <loc>https://tlienart.github.io/FranklinTemplates.jl/index.html</loc>
+    <lastmod>2023-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
 </url>

--- a/__site/tag/code/index.html
+++ b/__site/tag/code/index.html
@@ -33,7 +33,7 @@
     <h1>Tag: code</h1>
     <ul><li><a href="/">Franklin Example</a></li></ul>
     <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 
   </div>

--- a/__site/tag/syntax/index.html
+++ b/__site/tag/syntax/index.html
@@ -33,7 +33,7 @@
     <h1>Tag: syntax</h1>
     <ul><li><a href="/">Franklin Example</a></li></ul>
     <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>
 
   </div>

--- a/_layout/page_foot.html
+++ b/_layout/page_foot.html
@@ -1,3 +1,3 @@
 <div class="page-foot">
-    website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    website built with <a href="https://github.com/tlienart/Franklin.jl" target="_blank" rel="nooopener noreferrer">Franklin.jl</a> and the <a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia programming language</a>.
 </div>

--- a/index.md
+++ b/index.md
@@ -3,10 +3,10 @@
 
 # Julia for Deep Learning
 
-A course repository to follow along fast.ai using [Julia](https://julialang.org)!
+A course repository to follow along fast.ai using ~~~<a href="https://julialang.org" target="_blank" rel="nooopener noreferrer">Julia</a>~~~!
 
-Welcome! Here’s where you can find all the information you’ll need on the course. The goal of these docs is to follow along with the course [fast.ai](https://fast.ai), a stellar deep learning course. fast.ai is implemented in Python, but I personally strongly prefer Julia, and have always wanted to learn more deep learning. 
+Welcome! Here’s where you can find all the information you’ll need on the course. The goal of these docs is to follow along with the course ~~~<a href="https://fast.ai" target="_blank" rel="nooopener noreferrer">fast.ai</a>~~~, a stellar deep learning course. fast.ai is implemented in Python, but I personally strongly prefer Julia, and have always wanted to learn more deep learning.
 
 We’ll be implementing the fast.ai tutorials in Julia and going through them collaboratively. Every two weeks we’ll assign some reading and personal exercises, and then meet to discuss pain points/implementations/etc. 
 
-Check out our [GitHub](https://github.com/cpfiffer/julia-deeplearning) for more, and join our [Discord](https://discord.gg/zr5RVdWxs2)!
+Check out our ~~~<a href="https://github.com/cpfiffer/julia-deeplearning" target="_blank" rel="nooopener noreferrer">GitHub</a>~~~ for more, and join our ~~~<a href="https://discord.gg/zr5RVdWxs2" target="_blank" rel="nooopener noreferrer">Discord</a>~~~!

--- a/resources.md
+++ b/resources.md
@@ -4,4 +4,4 @@ Here's some handy links and references.
 
 ## Links
 
-- [fast.ai](https://fast.ai)
+- ~~~<a href="https://fast.ai" target="_blank" rel="nooopener noreferrer">fast.ai</a>~~~


### PR DESCRIPTION
I think it's a bit nicer if external links open in a new tab, but doing this in markdown is not usually possible. You can inject raw HTML by fencing it with `~~~..~~~`  (see [Franklin docs](https://franklinjl.org/syntax/markdown/#raw_html)).

I've just modified the existing external links in `index.md`, `resources.md` and in the footer. 